### PR TITLE
Fix dim( ) function

### DIFF
--- a/Adafruit_SH1106.cpp
+++ b/Adafruit_SH1106.cpp
@@ -438,7 +438,7 @@ void Adafruit_SH1106::startscrolldiagleft(uint8_t start, uint8_t stop){
 void Adafruit_SH1106::stopscroll(void){
   SH1106_command(SH1106_DEACTIVATE_SCROLL);
 }
-
+*/
 // Dim the display
 // dim = true: display is dimmed
 // dim = false: display is normal
@@ -458,7 +458,7 @@ void Adafruit_SH1106::dim(boolean dim) {
   // it is useful to dim the display
   SH1106_command(SH1106_SETCONTRAST);
   SH1106_command(contrast);
-}*/
+}
 
 void Adafruit_SH1106::SH1106_data(uint8_t c) {
  

--- a/Adafruit_SH1106.h
+++ b/Adafruit_SH1106.h
@@ -159,7 +159,7 @@ class Adafruit_SH1106 : public Adafruit_GFX {
   void startscrolldiagleft(uint8_t start, uint8_t stop);
   void stopscroll(void); */
   
-  void dim(uint8_t contrast);
+  void dim(boolean dim);
 
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 


### PR DESCRIPTION
The dim( ) function was commented out, but I found that the function works on my SH1106 1.3" OLED board if the function is restored and a small fix made to the Adafruit_1106.cpp to define the input parameter as boolean.