### PR TITLE
Restore dim() function

### DIFF
--- a/Adafruit_SH1106.cpp
+++ b/Adafruit_SH1106.cpp
@@ -438,6 +438,7 @@ void Adafruit_SH1106::startscrolldiagleft(uint8_t start, uint8_t stop){
 void Adafruit_SH1106::stopscroll(void){
   SH1106_command(SH1106_DEACTIVATE_SCROLL);
 }
+*/
 
 // Dim the display
 // dim = true: display is dimmed
@@ -458,7 +459,7 @@ void Adafruit_SH1106::dim(boolean dim) {
   // it is useful to dim the display
   SH1106_command(SH1106_SETCONTRAST);
   SH1106_command(contrast);
-}*/
+}
 
 void Adafruit_SH1106::SH1106_data(uint8_t c) {
  

--- a/Adafruit_SH1106.h
+++ b/Adafruit_SH1106.h
@@ -159,7 +159,7 @@ class Adafruit_SH1106 : public Adafruit_GFX {
   void startscrolldiagleft(uint8_t start, uint8_t stop);
   void stopscroll(void); */
   
-  void dim(uint8_t contrast);
+  void dim(boolean dim);
 
   void drawPixel(int16_t x, int16_t y, uint16_t color);
 


### PR DESCRIPTION
Restore dim( ) function by removing it from commented section in .cpp file and fixing the declaration in the .h file by changing the input parameter to boolean to match.