### PR TITLE
Added support for ESP8266 and ESP32 - not fully tested

### DIFF
--- a/Adafruit_SH1106.cpp
+++ b/Adafruit_SH1106.cpp
@@ -551,7 +551,7 @@ void Adafruit_SH1106::display(void) {
 	else{
 		
 	 // save I2C bitrate
-    #ifdef __AVR__
+    #ifdef TWBR
     		uint8_t twbrbackup = TWBR;
     		TWBR = 12; // upgrade to 400KHz!
 	#endif
@@ -573,7 +573,7 @@ void Adafruit_SH1106::display(void) {
         	}
 	}
 
-    #ifdef __AVR__
+    #ifdef TWBR
     		TWBR = twbrbackup;
 	#endif
 	}

--- a/Adafruit_SH1106.cpp
+++ b/Adafruit_SH1106.cpp
@@ -26,12 +26,16 @@ However, SH1106 driver don't provide several functions such as scroll commands.
 
 *********************************************************************/
 
-#include <avr/pgmspace.h>
-#ifndef __SAM3X8E__
- #include <util/delay.h>
+#ifdef __AVR__
+    #include <avr/pgmspace.h>
+    #ifndef __SAM3X8E__
+        #include <util/delay.h>
+    #endif
+#elif defined(ESP8266) || defined(ESP32)
+    #include <pgmspace.h>
 #endif
-#include <stdlib.h>
 
+#include <stdlib.h>
 #include <Wire.h>
 
 #include "Adafruit_GFX.h"
@@ -547,7 +551,7 @@ void Adafruit_SH1106::display(void) {
 	else{
 		
 	 // save I2C bitrate
-	#ifndef __SAM3X8E__
+    #ifdef __AVR__
     		uint8_t twbrbackup = TWBR;
     		TWBR = 12; // upgrade to 400KHz!
 	#endif
@@ -568,8 +572,8 @@ void Adafruit_SH1106::display(void) {
             Wire.endTransmission();
         	}
 	}
-	
-	#ifndef __SAM3X8E__
+
+    #ifdef __AVR__
     		TWBR = twbrbackup;
 	#endif
 	}

--- a/Adafruit_SH1106.h
+++ b/Adafruit_SH1106.h
@@ -27,19 +27,22 @@ However, SH1106 driver don't provide several functions such as scroll commands.
 *********************************************************************/
 
 #if ARDUINO >= 100
- #include "Arduino.h"
- #define WIRE_WRITE Wire.write
+    #include "Arduino.h"
+    #define WIRE_WRITE Wire.write
 #else
- #include "WProgram.h"
-  #define WIRE_WRITE Wire.send
+    #include "WProgram.h"
+    #define WIRE_WRITE Wire.send
 #endif
 
 #ifdef __SAM3X8E__
- typedef volatile RwReg PortReg;
- typedef uint32_t PortMask;
+    typedef volatile RwReg PortReg;
+    typedef uint32_t PortMask;
+#elif defined(ARDUINO_ARCH_ESP32) || defined(ESP32) || defined(ARDUINO_ARCH_ESP8266) || defined(ESP8266)
+    typedef volatile uint32_t PortReg;
+    typedef uint32_t PortMask;
 #else
-  typedef volatile uint8_t PortReg;
-  typedef uint8_t PortMask;
+    typedef volatile uint8_t PortReg;
+    typedef uint8_t PortMask;
 #endif
 
 #include <SPI.h>


### PR DESCRIPTION
Added compiler flag checks and correct int sizes for ESP8266 and ESP32;
Wrapped AVR specific includes and code inside AVR precompiler directives;
Wrapped TWBR usage inside #ifdef directive.

**This is not fully tested.** 
Only had the chance to test with ESP8266 and ESP32.